### PR TITLE
feat: --existing-models flag reuses pre-generated KCL models (fixes #18)

### DIFF
--- a/pkg/cmds/kcl-openapi.go
+++ b/pkg/cmds/kcl-openapi.go
@@ -1,9 +1,11 @@
 package cmds
 
 import (
+	"fmt"
 	"io"
 	"log"
 	"os"
+	"strings"
 
 	crdGen "kcl-lang.io/kcl-openapi/pkg/kube_resource/generator"
 	"kcl-lang.io/kcl-openapi/pkg/swagger/generator"
@@ -37,12 +39,13 @@ type Model struct {
 }
 
 type options struct {
-	Spec                 flags.Filename `long:"spec" short:"f" description:"the path to the OpenAPI spec file. It should be a local path in your file system" group:"shared"`
-	Crd                  bool           `long:"crd" description:"if the spec file is a kubernetes CRD" group:"shared"`
-	Target               flags.Filename `long:"target" short:"t" default:"./" description:"the base directory for generating the files" group:"shared"`
-	SkipValidation       bool           `long:"skip-validation" description:"skips validation of spec prior to generation" group:"shared"`
-	ModelPackage         string         `long:"model-package" short:"m" description:"the package to save the models" default:"models"`
-	DisableKeepSpecOrder bool           `long:"disable-keep-spec-order" description:"disable to keep schema properties order identical to spec file"`
+	Spec                 flags.Filename   `long:"spec" short:"f" description:"the path to the OpenAPI spec file. It should be a local path in your file system" group:"shared"`
+	Crd                  bool             `long:"crd" description:"if the spec file is a kubernetes CRD" group:"shared"`
+	Target               flags.Filename   `long:"target" short:"t" default:"./" description:"the base directory for generating the files" group:"shared"`
+	SkipValidation       bool             `long:"skip-validation" description:"skips validation of spec prior to generation" group:"shared"`
+	ModelPackage         string           `long:"model-package" short:"m" description:"the package to save the models" default:"models"`
+	DisableKeepSpecOrder bool             `long:"disable-keep-spec-order" description:"disable to keep schema properties order identical to spec file"`
+	ExistingModels       []flags.Filename `long:"existing-models" description:"reuse pre-generated KCL models from the given directory; the generator emits an import statement referencing <alias> instead of regenerating the schema files. Format: <alias>=<dir>. May be repeated." value-name:"ALIAS=PATH"`
 }
 
 func Main() {
@@ -90,6 +93,18 @@ func (m *Model) Execute(args []string) error {
 	opts.ValidateSpec = !m.Options.SkipValidation
 	opts.ModelPackage = m.Options.ModelPackage
 	opts.KeepOrder = !m.Options.DisableKeepSpecOrder
+
+	// Parse --existing-models entries (format: <alias>=<dir>).
+	for _, raw := range m.Options.ExistingModels {
+		alias, dir, ok := strings.Cut(string(raw), "=")
+		if !ok || alias == "" || dir == "" {
+			return fmt.Errorf("invalid --existing-models %q: expected <alias>=<dir>", raw)
+		}
+		opts.ExistingModels = append(opts.ExistingModels, generator.ExistingModel{
+			Alias: alias,
+			Path:  dir,
+		})
+	}
 
 	// set default configurations
 	if err := opts.EnsureDefaults(); err != nil {

--- a/pkg/swagger/generator/existing.go
+++ b/pkg/swagger/generator/existing.go
@@ -52,8 +52,13 @@ func LoadExistingModels(existing []ExistingModel) (map[string]string, error) {
 	if len(existing) == 0 {
 		return nil, nil
 	}
+	// out keeps only the alias because that's what GenOpts.ExistingDefs
+	// expects. We retain the path of the *first* declaration of each
+	// schema name in schemaSources so a conflict can report the directory
+	// the duplicate was originally discovered in.
 	out := make(map[string]string)
 	aliasPaths := make(map[string]string)
+	schemaSources := make(map[string]string)
 	for _, e := range existing {
 		if e.Alias == "" || e.Path == "" {
 			return nil, fmt.Errorf("existing-model entry requires non-empty alias and path, got %+v", e)
@@ -77,8 +82,11 @@ func LoadExistingModels(existing []ExistingModel) (map[string]string, error) {
 			for _, m := range schemaNameRegexp.FindAllStringSubmatch(string(content), -1) {
 				name := m[1]
 				if prev, ok := out[name]; ok && prev != e.Alias {
-					return nil, fmt.Errorf("schema %q is declared in multiple existing-model directories (%q under %q and %q under %q)",
-						name, e.Path, e.Alias, "<other>", prev)
+					return nil, fmt.Errorf("schema %q is declared in multiple existing-model directories (%q under alias %q and %q under alias %q)",
+						name, schemaSources[name], prev, e.Path, e.Alias)
+				}
+				if _, already := out[name]; !already {
+					schemaSources[name] = e.Path
 				}
 				out[name] = e.Alias
 			}

--- a/pkg/swagger/generator/existing.go
+++ b/pkg/swagger/generator/existing.go
@@ -1,0 +1,88 @@
+// Copyright 2024 The KCL Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+
+package generator
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+)
+
+// ExistingModel describes a directory of pre-existing KCL models that the
+// generator should reference via `import` instead of regenerating.
+//
+// When the generator encounters a schema in the spec whose name matches a
+// schema discovered in an ExistingModel.Path, it skips the generation of
+// that schema's file and instead emits cross-package references as
+// `<alias>.<SchemaName>` (backed by an `import <alias>` statement).
+type ExistingModel struct {
+	// Alias is the import alias referenced by the generator when emitting
+	// cross-package references to schemas discovered in Path.
+	Alias string
+	// Path is the directory containing pre-existing KCL model files (*.k).
+	Path string
+}
+
+// schemaNameRegexp matches KCL `schema <Name>` (optionally followed by
+// `(Base1, Base2)` for protocol/mixin inheritance) followed by a colon.
+// It deliberately ignores indented schema bodies (e.g. items declared
+// inside a list or dict) by requiring the leading whitespace to be zero or
+// short.
+var schemaNameRegexp = regexp.MustCompile(`(?m)^[ \t]{0,8}schema[ \t]+([A-Za-z_][A-Za-z0-9_]*)[ \t]*(?:\([^)]*\))?[ \t]*:`)
+
+// LoadExistingModels scans each existing-model directory for `.k` files
+// and extracts schema names. It returns a map keyed by the discovered
+// schema name to its alias, suitable for use as GenOpts.ExistingDefs.
+//
+// The function performs the following sanity checks:
+//   - each existing-model entry has a non-empty alias and path
+//   - aliases are unique across entries
+//   - the same schema name does not appear under two different aliases
+//
+// On error, the partial result is discarded.
+func LoadExistingModels(existing []ExistingModel) (map[string]string, error) {
+	if len(existing) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]string)
+	aliasPaths := make(map[string]string)
+	for _, e := range existing {
+		if e.Alias == "" || e.Path == "" {
+			return nil, fmt.Errorf("existing-model entry requires non-empty alias and path, got %+v", e)
+		}
+		if prev, ok := aliasPaths[e.Alias]; ok && prev != e.Path {
+			return nil, fmt.Errorf("existing-model alias %q is reused by %q and %q", e.Alias, prev, e.Path)
+		}
+		aliasPaths[e.Alias] = e.Path
+	}
+	for _, e := range existing {
+		files, err := filepath.Glob(filepath.Join(e.Path, "*.k"))
+		if err != nil {
+			return nil, fmt.Errorf("scan existing-models dir %q: %v", e.Path, err)
+		}
+		sort.Strings(files)
+		for _, f := range files {
+			content, err := os.ReadFile(f)
+			if err != nil {
+				return nil, fmt.Errorf("read existing-model file %q: %v", f, err)
+			}
+			for _, m := range schemaNameRegexp.FindAllStringSubmatch(string(content), -1) {
+				name := m[1]
+				if prev, ok := out[name]; ok && prev != e.Alias {
+					return nil, fmt.Errorf("schema %q is declared in multiple existing-model directories (%q under %q and %q under %q)",
+						name, e.Path, e.Alias, "<other>", prev)
+				}
+				out[name] = e.Alias
+			}
+		}
+	}
+	return out, nil
+}

--- a/pkg/swagger/generator/model.go
+++ b/pkg/swagger/generator/model.go
@@ -37,9 +37,30 @@ func makeGenDefinition(name, pkg string, schema spec.Schema, specDoc *loads.Docu
 }
 
 func makeGenDefinitionHierarchy(name, pkg, container string, schema spec.Schema, specDoc *loads.Document, opts *GenOpts) (*GenDefinition, error) {
+	// If this definition is supplied by an existing-model directory,
+	// emit a stub GenDefinition with External=true. The model file is
+	// not generated; cross-references are produced via `import <alias>`
+	// by the type resolver when it resolves $refs to this name.
+	if alias, ok := opts.ExistingDefs[name]; ok {
+		log.Printf("skipping generation of %s (provided by existing-models alias %q)", name, alias)
+		gs := GenSchema{Name: name, OriginalName: name}
+		gs.KclType = name
+		gs.Pkg = alias
+		gs.PkgAlias = alias
+		gs.Module = alias
+		return &GenDefinition{
+			GenCommon: GenCommon{
+				Copyright:        opts.Copyright,
+				TargetImportPath: opts.LanguageOpts.baseImport(opts.Target),
+			},
+			Package:   opts.LanguageOpts.ManglePackageName(path.Base(filepath.ToSlash(pkg)), "definitions"),
+			GenSchema: gs,
+			External:  true,
+		}, nil
+	}
 	receiver := "m"
 	// models are resolved in the current package
-	resolver := newTypeResolver("", specDoc)
+	resolver := newTypeResolverWith("", specDoc, opts.ExistingDefs)
 	resolver.ModelName = name
 	analyzed := analysis.New(specDoc.Spec())
 

--- a/pkg/swagger/generator/shared.go
+++ b/pkg/swagger/generator/shared.go
@@ -89,6 +89,16 @@ type GenOpts struct {
 	FlagStrategy      string
 	CompatibilityMode string
 	Copyright         string
+
+	// ExistingModels lists pre-existing KCL model directories that the
+	// generator should reference via `import` instead of regenerating.
+	// See `LoadExistingModels` for the schema-name extraction rules.
+	ExistingModels []ExistingModel
+	// ExistingDefs is populated by `LoadExistingModels` (called from
+	// `newGenerator`) and exposed to the type resolver and codegen
+	// pipeline. It maps a discovered schema's simple name (the trailing
+	// segment of the spec definition key, e.g. "Pet") to its import alias.
+	ExistingDefs map[string]string
 }
 
 // CheckOpts carries out some global consistency checks on options.

--- a/pkg/swagger/generator/support.go
+++ b/pkg/swagger/generator/support.go
@@ -39,6 +39,15 @@ func newGenerator(opts *GenOpts) (*generator, error) {
 
 	opts.setTemplates()
 
+	// Resolve existing-models directories up front so the type resolver
+	// can consult them when deciding whether a definition is local or
+	// references an external alias.
+	existingDefs, err := LoadExistingModels(opts.ExistingModels)
+	if err != nil {
+		return nil, fmt.Errorf("load existing-models: %v", err)
+	}
+	opts.ExistingDefs = existingDefs
+
 	specDoc, analyzed, err := opts.analyzeSpec()
 	if err != nil {
 		return nil, err

--- a/pkg/swagger/generator/support_test.go
+++ b/pkg/swagger/generator/support_test.go
@@ -151,15 +151,22 @@ schema Beta:
 		// The error message must surface both directories and both aliases so
 		// the operator can locate the duplicates without guessing. Regression
 		// for the previous literal "<other>" placeholder bug.
+		//
+		// The error message embeds the paths through fmt's %q, which on
+		// Windows escapes every `\` as `\\`. Format the expected fragments
+		// the same way so the comparison works on every platform without
+		// string-level normalization (which previously turned the escaped
+		// `\\` into `//` while the expected fragment still had `/`).
+		msg := err.Error()
 		for _, fragment := range []string{
 			"Beta",
-			filepath.Join(tempDir, "shared"),
-			filepath.Join(tempDir, "other"),
+			fmt.Sprintf("%q", filepath.Join(tempDir, "shared")),
+			fmt.Sprintf("%q", filepath.Join(tempDir, "other")),
 			"\"shared\"",
 			"\"other\"",
 		} {
-			if !strings.Contains(err.Error(), fragment) {
-				t.Fatalf("error message %q is missing fragment %q", err.Error(), fragment)
+			if !strings.Contains(msg, fragment) {
+				t.Fatalf("error message %q is missing fragment %q", msg, fragment)
 			}
 		}
 	})

--- a/pkg/swagger/generator/support_test.go
+++ b/pkg/swagger/generator/support_test.go
@@ -101,6 +101,191 @@ echo "line two"
 	}
 }
 
+func TestLoadExistingModels(t *testing.T) {
+	tempDir := t.TempDir()
+	dir := filepath.Join(tempDir, "shared")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "alpha.k"), []byte(`"""alpha doc"""
+schema Alpha:
+    r"""Alpha schema"""
+    name?: str
+
+# a duplicate definition inside the same dir is fine, but a duplicate
+# across aliases must error
+schema Beta:
+    r"""Beta schema"""
+    name?: str
+`), 0o644); err != nil {
+		t.Fatalf("write alpha.k failed: %v", err)
+	}
+	otherDir := filepath.Join(tempDir, "other")
+	if err := os.MkdirAll(otherDir, 0o755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(otherDir, "beta.k"), []byte("schema Beta:\n    name?: str\n"), 0o644); err != nil {
+		t.Fatalf("write beta.k failed: %v", err)
+	}
+
+	t.Run("happy path", func(t *testing.T) {
+		got, err := LoadExistingModels([]ExistingModel{
+			{Alias: "shared", Path: filepath.Join(tempDir, "shared")},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got["Alpha"] != "shared" || got["Beta"] != "shared" {
+			t.Fatalf("unexpected map: %v", got)
+		}
+	})
+
+	t.Run("schema in multiple aliases fails", func(t *testing.T) {
+		_, err := LoadExistingModels([]ExistingModel{
+			{Alias: "shared", Path: filepath.Join(tempDir, "shared")},
+			{Alias: "other", Path: filepath.Join(tempDir, "other")},
+		})
+		if err == nil {
+			t.Fatalf("expected error for overlapping schema name")
+		}
+	})
+
+	t.Run("empty alias fails", func(t *testing.T) {
+		_, err := LoadExistingModels([]ExistingModel{
+			{Alias: "", Path: filepath.Join(tempDir, "shared")},
+		})
+		if err == nil {
+			t.Fatalf("expected error for empty alias")
+		}
+	})
+
+	t.Run("empty input returns nil", func(t *testing.T) {
+		got, err := LoadExistingModels(nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != nil {
+			t.Fatalf("expected nil map, got %v", got)
+		}
+	})
+}
+
+func TestGenerate_OAI2KCL_ExistingModels(t *testing.T) {
+	tempDir := t.TempDir()
+
+	existingDir := filepath.Join(tempDir, "existing")
+	if err := os.MkdirAll(existingDir, 0o755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(existingDir, "cat.k"), []byte(`"""pre-existing cat model"""
+schema Cat:
+    r"""Cat schema"""
+    name?: str
+`), 0o644); err != nil {
+		t.Fatalf("write cat.k failed: %v", err)
+	}
+
+	specPath := filepath.Join(tempDir, "spec.yaml")
+	if err := os.WriteFile(specPath, []byte(`swagger: "2.0"
+info:
+  title: test
+  version: "0.0.1"
+paths: {}
+definitions:
+  Cat:
+    type: object
+    properties:
+      name:
+        type: string
+  Owner:
+    type: object
+    properties:
+      name:
+        type: string
+      pet:
+        $ref: "#/definitions/Cat"
+`), 0o644); err != nil {
+		t.Fatalf("write spec failed: %v", err)
+	}
+
+	if err := apiConvertModel(utils.IntegrationGenOpts{
+		SpecPath:       specPath,
+		TargetDir:      tempDir,
+		ModelPackage:   "models",
+		ExistingModels: []string{"existing=" + existingDir},
+	}); err != nil {
+		t.Fatalf("generate failed: %v", err)
+	}
+
+	// Cat.k should NOT be generated (it is provided by the existing-models dir).
+	catPath := filepath.Join(tempDir, "models", "cat.k")
+	if _, err := os.Stat(catPath); err == nil {
+		t.Fatalf("expected cat.k NOT to be generated (External=true), but it exists:\n%s", catPath)
+	}
+
+	ownerPath := filepath.Join(tempDir, "models", "owner.k")
+	owner, err := os.ReadFile(ownerPath)
+	if err != nil {
+		t.Fatalf("read owner.k failed: %v", err)
+	}
+	content := string(owner)
+	if !strings.Contains(content, "import existing") {
+		t.Errorf("expected `import existing` in owner.k:\n%s", content)
+	}
+	if !strings.Contains(content, "existing.Cat") {
+		t.Errorf("expected `existing.Cat` reference in owner.k:\n%s", content)
+	}
+}
+
+func TestGenerate_OAI2KCL_NoMatch_ExistingModels(t *testing.T) {
+	// When an existing-models directory is provided but none of its
+	// schemas appear in the spec, generation proceeds unchanged.
+	tempDir := t.TempDir()
+
+	existingDir := filepath.Join(tempDir, "existing")
+	if err := os.MkdirAll(existingDir, 0o755); err != nil {
+		t.Fatalf("mkdir failed: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(existingDir, "ghost.k"), []byte("schema Ghost:\n    name?: str\n"), 0o644); err != nil {
+		t.Fatalf("write ghost.k failed: %v", err)
+	}
+
+	specPath := filepath.Join(tempDir, "spec.yaml")
+	if err := os.WriteFile(specPath, []byte(`swagger: "2.0"
+info:
+  title: test
+  version: "0.0.1"
+paths: {}
+definitions:
+  Owner:
+    type: object
+    properties:
+      name:
+        type: string
+`), 0o644); err != nil {
+		t.Fatalf("write spec failed: %v", err)
+	}
+
+	if err := apiConvertModel(utils.IntegrationGenOpts{
+		SpecPath:       specPath,
+		TargetDir:      tempDir,
+		ModelPackage:   "models",
+		ExistingModels: []string{"existing=" + existingDir},
+	}); err != nil {
+		t.Fatalf("generate failed: %v", err)
+	}
+
+	ownerPath := filepath.Join(tempDir, "models", "owner.k")
+	owner, err := os.ReadFile(ownerPath)
+	if err != nil {
+		t.Fatalf("read owner.k failed: %v", err)
+	}
+	content := string(owner)
+	if strings.Contains(content, "import existing") {
+		t.Errorf("expected no `import existing` when no schema matched:\n%s", content)
+	}
+}
+
 func apiConvertModel(integrationGenOpts utils.IntegrationGenOpts) error {
 	opts := new(GenOpts)
 	opts.Spec = integrationGenOpts.SpecPath
@@ -108,6 +293,13 @@ func apiConvertModel(integrationGenOpts utils.IntegrationGenOpts) error {
 	opts.KeepOrder = true
 	opts.ValidateSpec = !integrationGenOpts.IsCrd
 	opts.ModelPackage = integrationGenOpts.ModelPackage
+	for _, raw := range integrationGenOpts.ExistingModels {
+		alias, dir, ok := strings.Cut(raw, "=")
+		if !ok || alias == "" || dir == "" {
+			return fmt.Errorf("invalid existing-models entry %q: expected <alias>=<dir>", raw)
+		}
+		opts.ExistingModels = append(opts.ExistingModels, ExistingModel{Alias: alias, Path: dir})
+	}
 
 	if err := opts.EnsureDefaults(); err != nil {
 		return fmt.Errorf("fill default options failed: %s", err.Error())

--- a/pkg/swagger/generator/support_test.go
+++ b/pkg/swagger/generator/support_test.go
@@ -148,6 +148,20 @@ schema Beta:
 		if err == nil {
 			t.Fatalf("expected error for overlapping schema name")
 		}
+		// The error message must surface both directories and both aliases so
+		// the operator can locate the duplicates without guessing. Regression
+		// for the previous literal "<other>" placeholder bug.
+		for _, fragment := range []string{
+			"Beta",
+			filepath.Join(tempDir, "shared"),
+			filepath.Join(tempDir, "other"),
+			"\"shared\"",
+			"\"other\"",
+		} {
+			if !strings.Contains(err.Error(), fragment) {
+				t.Fatalf("error message %q is missing fragment %q", err.Error(), fragment)
+			}
+		}
 	})
 
 	t.Run("empty alias fails", func(t *testing.T) {

--- a/pkg/swagger/generator/types.go
+++ b/pkg/swagger/generator/types.go
@@ -61,9 +61,23 @@ func initTypes() {
 }
 
 func newTypeResolver(pkg string, doc *loads.Document) *typeResolver {
-	resolver := typeResolver{ModelsPackage: pkg, Doc: doc}
+	return newTypeResolverWith(pkg, doc, nil)
+}
+
+// newTypeResolverWith builds a typeResolver optionally seeded with an
+// existing-defs map (schema name → alias). Definitions whose simple name
+// is present in existingDefs are excluded from KnownDefs because they
+// will be referenced via cross-package imports rather than local names.
+func newTypeResolverWith(pkg string, doc *loads.Document, existingDefs map[string]string) *typeResolver {
+	resolver := typeResolver{ModelsPackage: pkg, Doc: doc, ExistingDefs: existingDefs}
 	resolver.KnownDefs = make(map[string]struct{}, len(doc.Spec().Definitions))
 	for k, sch := range doc.Spec().Definitions {
+		simpleName := filepath.Base(k)
+		if _, ok := resolver.ExistingDefs[simpleName]; ok {
+			// Skip: this definition will be referenced via the existing
+			// model's alias instead of being emitted as a local type.
+			continue
+		}
 		tpe, _, _, _ := knownDefKclType(k, sch, nil)
 		resolver.KnownDefs[tpe] = struct{}{}
 	}
@@ -136,6 +150,11 @@ type typeResolver struct {
 	ModelsPackage string
 	ModelName     string
 	KnownDefs     map[string]struct{}
+	// ExistingDefs, when non-empty, maps a definition's simple name to the
+	// alias of an existing-model directory that already provides the
+	// schema. Resolved references to such definitions produce a cross-
+	// package `import <alias>` rather than a local reference.
+	ExistingDefs map[string]string
 	// unexported fields
 	keepDefinitionsPkg string
 	knownDefsKept      map[string]struct{}
@@ -143,7 +162,7 @@ type typeResolver struct {
 
 // NewWithModelName clones a type resolver and specifies a new model name
 func (t *typeResolver) NewWithModelName(name string) *typeResolver {
-	tt := newTypeResolver(t.ModelsPackage, t.Doc)
+	tt := newTypeResolverWith(t.ModelsPackage, t.Doc, t.ExistingDefs)
 	tt.ModelName = name
 
 	// propagates kept definitions
@@ -175,6 +194,19 @@ func (t *typeResolver) resolveSchemaRef(schema *spec.Schema, isRequired bool) (r
 	result = res
 
 	tn := filepath.Base(schema.Ref.GetURL().Fragment)
+	// If the referenced schema is provided by an existing-model
+	// directory, prefer the cross-package import reference over the
+	// local (or absent) one returned by knownDefKclType.
+	if alias, ok := t.ExistingDefs[tn]; ok {
+		debugLog("ref %s -> existing alias %s", tn, alias)
+		result.KclType = tn
+		result.Pkg = alias
+		result.PkgAlias = alias
+		result.Module = alias
+		result.HasDiscriminator = res.HasDiscriminator
+		result.IsBaseType = res.HasDiscriminator
+		return
+	}
 	tpe, pkg, alias, module := knownDefKclType(tn, *ref, t.kclTypeName)
 	debugLog("type name %s, package %s, alias %s, module %s", tpe, pkg, alias, module)
 	if tpe != "" {
@@ -314,11 +346,22 @@ func (t *typeResolver) resolveObject(schema *spec.Schema, isAnonymous bool) (res
 
 	if !isAnonymous {
 		result.SwaggerType = object
-		tpe, pkg, alias, module := knownDefKclType(t.ModelName, *schema, t.kclTypeName)
-		result.KclType = tpe
-		result.Pkg = pkg
-		result.PkgAlias = alias
-		result.Module = module
+		if alias, ok := t.ExistingDefs[t.ModelName]; ok {
+			// The model itself is provided by an existing-model
+			// directory; treat it as a remote reference so cross-file
+			// collectors emit `import <alias>`.
+			debugLog("object %s -> existing alias %s", t.ModelName, alias)
+			result.KclType = t.ModelName
+			result.Pkg = alias
+			result.PkgAlias = alias
+			result.Module = alias
+		} else {
+			tpe, pkg, alias, module := knownDefKclType(t.ModelName, *schema, t.kclTypeName)
+			result.KclType = tpe
+			result.Pkg = pkg
+			result.PkgAlias = alias
+			result.Module = module
+		}
 	}
 	if len(schema.AllOf) > 0 {
 		result.KclType = t.kclTypeName(t.ModelName)

--- a/pkg/utils/integrate_gen.go
+++ b/pkg/utils/integrate_gen.go
@@ -45,6 +45,10 @@ type IntegrationGenOpts struct {
 	TargetDir    string
 	IsCrd        bool
 	ModelPackage string
+	// ExistingModels is a list of <alias>=<dir> pairs. When set, the
+	// generator imports schemas discovered in <dir> under <alias>
+	// instead of regenerating them.
+	ExistingModels []string
 }
 
 func InitTestDirs(projectRoot string, buildBinary bool) error {


### PR DESCRIPTION
## Summary

Adds a repeatable `--existing-models <alias>=<dir>` CLI option that lets the
generator reference pre-existing KCL models via `import` instead of
regenerating them. When a spec definition's schema name is discovered in
one of the given directories, its file generation is skipped and any
cross-references resolve to `<alias>.<SchemaName>` backed by an `import
<alias>` statement.

The scanner walks each directory's `*.k` files and extracts `schema
<Name>` declarations (with optional `(Base1, Base2)` inheritance). It
performs two sanity checks: aliases must be unique across `--existing-
models` entries, and a schema name must not appear under two different
aliases.

## Example

```sh
$ kcl-openapi generate model \
    -f spec.yaml \
    -t ./out \
    --existing-models shared=./existing_models \
    --existing-models k8s=./k8s_models
```

When `spec.yaml` defines `Owner` with a `$ref` to `Cat`, and `Cat` is
found in `./existing_models/cat.k`, the output is:

```kcl
schema Owner:
    ...
    pet?: shared.Cat
```

with `cat.k` *not* generated under `./out/models/`. The file `out/models/owner.k`
contains the `import shared` statement.

## Implementation

- New `pkg/swagger/generator/existing.go` defines `ExistingModel` and
  `LoadExistingModels`.
- `GenOpts.ExistingModels` (slice) and `ExistingDefs` (map populated by
  the loader) are added in `shared.go`.
- `newGenerator` in `support.go` calls `LoadExistingModels` once at
  startup.
- `typeResolver.ExistingDefs` field and `newTypeResolverWith` in
  `types.go` carry the map into schema resolution.
- `resolveSchemaRef` and `resolveObject` short-circuit to the alias when
  the model name matches an existing def.
- `makeGenDefinitionHierarchy` returns an `External: true` stub for
  matches so `makeCodegen` skips appending them to the rendering list.

## Tests

- `TestLoadExistingModels`: happy path, duplicate-name error, empty
  alias error, empty input.
- `TestGenerate_OAI2KCL_ExistingModels`: full integration test that
  verifies `cat.k` is *not* generated and `owner.k` contains
  `import existing` and `existing.Cat`.
- `TestGenerate_OAI2KCL_NoMatch_ExistingModels`: baseline (no import
  emitted when no schema matches).

The whole `pkg/swagger/generator` test suite still passes.

## Test plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `gofmt -l pkg/` clean
- [x] `go vet ./...` clean
- [x] End-to-end CLI smoke test with a hand-written spec and an
      existing `cat.k` directory.