### PR TITLE
chore(ci): drop Go 1.23 from Linux build matrix

### DIFF
--- a/.github/workflows/main_linux.yml
+++ b/.github/workflows/main_linux.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [ '1.23', '1.24' ]
+        go-version: [ '1.24' ]
     steps:
       - name: Git checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
Prerequisite for dependabot PRs #133, #136, #137, #138, which all bump go.mod's `go` directive to `1.24.0`. Go 1.23 cannot build a module declaring `go 1.24.0`, so dropping 1.23 from the matrix lets those PRs merge without touching workflow files. 1.24 stays as the single tested version, matching the matrix Darwin/Windows already use implicitly via setup-go defaults.