### PR TITLE
fix(generator): emit valid KCL from CEL x-kubernetes-validations

### DIFF
--- a/pkg/swagger/generator/cel.go
+++ b/pkg/swagger/generator/cel.go
@@ -82,15 +82,7 @@ func emitKCL(e *exprpb.Expr) (string, error) {
 	case *exprpb.Expr_IdentExpr:
 		return k.IdentExpr.GetName(), nil
 	case *exprpb.Expr_SelectExpr:
-		operand, err := emitKCL(k.SelectExpr.GetOperand())
-		if err != nil {
-			return "", err
-		}
-		if k.SelectExpr.GetTestOnly() {
-			// `has(m.f)` macro expands to a Select with TestOnly=true.
-			return fmt.Sprintf("(has %s.%s)", operand, k.SelectExpr.GetField()), nil
-		}
-		return fmt.Sprintf("%s.%s", operand, k.SelectExpr.GetField()), nil
+		return emitSelect(k.SelectExpr)
 	case *exprpb.Expr_CallExpr:
 		return emitCall(k.CallExpr)
 	case *exprpb.Expr_ComprehensionExpr:
@@ -101,6 +93,44 @@ func emitKCL(e *exprpb.Expr) (string, error) {
 		return emitStruct(k.StructExpr)
 	}
 	return unsupportedPlaceholder("ast-node", fmt.Sprintf("%T", e.GetExprKind()))
+}
+
+// emitSelect translates a CEL field-select or presence-test. KCL `check:`
+// blocks reference schema attributes directly without `self`, so when the
+// operand is the bare identifier `self` we strip the prefix. When the
+// select is a CEL presence test (`has(self.f)`), we translate it to the
+// KCL equivalent `f != None` so the rule stays semantically meaningful
+// inside a schema check. Non-`self` operands are kept verbatim so that
+// constructs we don't know how to translate still produce a placeholder
+// the caller can detect.
+func emitSelect(s *exprpb.Expr_Select) (string, error) {
+	isSelf := isSelfIdent(s.GetOperand())
+	if s.GetTestOnly() {
+		if isSelf {
+			return fmt.Sprintf("(%s != None)", s.GetField()), nil
+		}
+		// `has(m.f)` for non-`self` operands: KCL has no `has` and we
+		// can't express "attribute of an arbitrary value" safely, so
+		// mark the rule unsupported and let the caller drop it.
+		return unsupportedPlaceholder("has", s.GetField())
+	}
+	if isSelf {
+		return s.GetField(), nil
+	}
+	operand, err := emitKCL(s.GetOperand())
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s.%s", operand, s.GetField()), nil
+}
+
+// isSelfIdent reports whether `e` is the bare CEL identifier `self`.
+func isSelfIdent(e *exprpb.Expr) bool {
+	id, ok := e.GetExprKind().(*exprpb.Expr_IdentExpr)
+	if !ok {
+		return false
+	}
+	return id.IdentExpr.GetName() == "self"
 }
 
 func emitConst(l *exprpb.Constant) (string, error) {
@@ -132,21 +162,12 @@ func emitCall(c *exprpb.Expr_Call) (string, error) {
 	fn := c.GetFunction()
 
 	// Ternary `cond ? a : b` is represented as a CallExpr with the
-	// function `_?_:_` and three arguments.
+	// function `_?_:_` and three arguments. KCL's `check:` block does
+	// not accept `if/else` expressions (the parser treats `else` as a
+	// bare name in that context), so we surface the rule as
+	// unsupported and let the caller drop it.
 	if fn == "_?_:_" {
-		cond, err := emitKCL(c.GetArgs()[0])
-		if err != nil {
-			return "", err
-		}
-		thenE, err := emitKCL(c.GetArgs()[1])
-		if err != nil {
-			return "", err
-		}
-		elseE, err := emitKCL(c.GetArgs()[2])
-		if err != nil {
-			return "", err
-		}
-		return fmt.Sprintf("(%s) if (%s) else (%s)", thenE, cond, elseE), nil
+		return unsupportedPlaceholder("ternary", "")
 	}
 
 	// Binary operators
@@ -229,6 +250,12 @@ func emitCall(c *exprpb.Expr_Call) (string, error) {
 	if fn == "size" {
 		if len(c.GetArgs()) != 1 {
 			return "", fmt.Errorf("cel: size() expects 1 arg, got %d", len(c.GetArgs()))
+		}
+		// `size(self)` asks for the field-count of the schema instance.
+		// KCL `check:` blocks have no handle for the instance, so we drop
+		// the rule rather than emit `len(self)` (undefined identifier).
+		if isSelfIdent(c.GetArgs()[0]) {
+			return unsupportedPlaceholder("size", "self")
 		}
 		arg, err := emitKCL(c.GetArgs()[0])
 		if err != nil {

--- a/pkg/swagger/generator/cel_test.go
+++ b/pkg/swagger/generator/cel_test.go
@@ -27,42 +27,48 @@ func TestCelToKCL(t *testing.T) {
 		{"literal sq string", `'abc'`, `"abc"`},
 
 		{"self ref", "self", "self"},
-		{"field access", "self.name", "self.name"},
-		{"deep field", "self.a.b.c", "self.a.b.c"},
-		{"index expr", "self.list[0]", "self.list[0]"},
+		{"field access", "self.name", "name"},
+		{"deep field", "self.a.b.c", "a.b.c"},
+		{"index expr", "self.list[0]", "list[0]"},
 
-		{"eq", `self.name == "x"`, `(self.name == "x")`},
-		{"neq", `self.x != "y"`, `(self.x != "y")`},
-		{"lt", "self.a < 10", "(self.a < 10)"},
-		{"lte", "self.a <= 10", "(self.a <= 10)"},
-		{"gt", "self.a > 10", "(self.a > 10)"},
-		{"gte", "self.a >= 10", "(self.a >= 10)"},
+		{"eq", `self.name == "x"`, `(name == "x")`},
+		{"neq", `self.x != "y"`, `(x != "y")`},
+		{"lt", "self.a < 10", "(a < 10)"},
+		{"lte", "self.a <= 10", "(a <= 10)"},
+		{"gt", "self.a > 10", "(a > 10)"},
+		{"gte", "self.a >= 10", "(a >= 10)"},
 
-		{"and", `self.a == 1 && self.b == 2`, `((self.a == 1) and (self.b == 2))`},
-		{"or", `self.a == 1 || self.b == 2`, `((self.a == 1) or (self.b == 2))`},
-		{"not", `!self.a`, `not (self.a)`},
-		{"precedence", `self.a || self.b && self.c`, `(self.a or (self.b and self.c))`},
-		{"paren group", `(self.a || self.b) && self.c`, `((self.a or self.b) and self.c)`},
+		{"and", `self.a == 1 && self.b == 2`, `((a == 1) and (b == 2))`},
+		{"or", `self.a == 1 || self.b == 2`, `((a == 1) or (b == 2))`},
+		{"not", `!self.a`, `not (a)`},
+		{"not has", `!has(self.foo)`, `not ((foo != None))`},
+		{"precedence", `self.a || self.b && self.c`, `(a or (b and c))`},
+		{"paren group", `(self.a || self.b) && self.c`, `((a or b) and c)`},
 
-		{"arith add", "self.a + self.b", "(self.a + self.b)"},
-		{"arith mul precedence", "self.a + self.b * self.c", "(self.a + (self.b * self.c))"},
-		{"unary minus", "-self.a", "(-self.a)"},
+		{"arith add", "self.a + self.b", "(a + b)"},
+		{"arith mul precedence", "self.a + self.b * self.c", "(a + (b * c))"},
+		{"unary minus", "-self.a", "(-a)"},
 
-		{"ternary", `self.a ? "x" : "y"`, `("x") if (self.a) else ("y")`},
+		// KCL's `check:` block does not accept `if/else` expressions (the
+		// parser treats `else` as a bare name there), so the translator
+		// surfaces ternary as an unsupported construct and the caller
+		// drops the rule.
+		{"ternary", `self.a ? "x" : "y"`, `__UNSUPPORTED_CEL_CALL_ternary__`},
 
-		{"size", "size(self.list)", "len(self.list)"},
-		{"matches", `self.email.matches("^.+@.+$")`, `_regex_match(str(self.email), "^.+@.+$")`},
-		{"startsWith", `self.name.startsWith("foo")`, `str(self.name).starts_with("foo")`},
-		{"endsWith", `self.name.endsWith("bar")`, `str(self.name).ends_with("bar")`},
-		{"has", "has(self.foo)", "(has self.foo)"},
+		{"size", "size(self.list)", "len(list)"},
+		{"size self", "size(self)", "__UNSUPPORTED_CEL_CALL_size(self)__"},
+		{"matches", `self.email.matches("^.+@.+$")`, `_regex_match(str(email), "^.+@.+$")`},
+		{"startsWith", `self.name.startsWith("foo")`, `str(name).starts_with("foo")`},
+		{"endsWith", `self.name.endsWith("bar")`, `str(name).ends_with("bar")`},
+		{"has", "has(self.foo)", "(foo != None)"},
 
-		{"all", `self.list.all(x, x > 0)`, "all x in self.list {\n    (x > 0)\n}"},
-		{"exists", `self.list.exists(x, x == "ok")`, "any x in self.list {\n    (x == \"ok\")\n}"},
+		{"all", `self.list.all(x, x > 0)`, "all x in list {\n    (x > 0)\n}"},
+		{"exists", `self.list.exists(x, x == "ok")`, "any x in list {\n    (x == \"ok\")\n}"},
 		{"exists_one", `self.list.exists_one(x, x == 1)`,
-			"sum([1 for x in self.list if (x == 1)]) == 1"},
+			"sum([1 for x in list if (x == 1)]) == 1"},
 
 		{"complex real", `self.minReplicas <= self.maxReplicas && size(self.list) > 0`,
-			`((self.minReplicas <= self.maxReplicas) and (len(self.list) > 0))`},
+			`((minReplicas <= maxReplicas) and (len(list) > 0))`},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -73,7 +79,12 @@ func TestCelToKCL(t *testing.T) {
 			if got != c.want {
 				t.Errorf("celToKCL(%q):\n got: %s\nwant: %s", c.in, got, c.want)
 			}
-			if isUnsupportedKCL(got) {
+			// The `want` value is itself a `__UNSUPPORTED_CEL_CALL_*`
+			// marker for cases the translator deliberately cannot
+			// render (e.g. ternary inside a KCL `check:` block). Those
+			// rules are dropped by k8s_validations.go.
+			wantUnsupported := strings.HasPrefix(c.want, "__UNSUPPORTED_CEL_CALL_")
+			if isUnsupportedKCL(got) && !wantUnsupported {
 				t.Errorf("celToKCL(%q) produced unsupported call placeholder: %s", c.in, got)
 			}
 		})

--- a/pkg/swagger/generator/model.go
+++ b/pkg/swagger/generator/model.go
@@ -244,6 +244,21 @@ func (schema *GenSchema) getBuiltInImports() map[string]importStmt {
 			IsBuiltIn:  true,
 		}
 	}
+	// CEL `x-kubernetes-validations` rules that use `.matches(...)`
+	// translate to KCL `_regex_match(...)`, requiring the `regex` import
+	// and the header alias. Without this, `collectSortedImports` would
+	// not set `HasPatternValidation`, the header would omit the alias,
+	// and the generated `check:` block would reference an undefined
+	// identifier.
+	for _, c := range schema.CheckExprs {
+		if strings.Contains(c.Expr, "_regex_match") {
+			imp[RegexPkgPath] = importStmt{
+				ImportPath: RegexPkgPath,
+				IsBuiltIn:  true,
+			}
+			break
+		}
+	}
 	if schema.Items != nil {
 		for k, v := range schema.Items.getBuiltInImports() {
 			imp[k] = v

--- a/pkg/swagger/generator/support_test.go
+++ b/pkg/swagger/generator/support_test.go
@@ -3,6 +3,7 @@ package generator
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -359,19 +360,78 @@ definitions:
 	for _, want := range []string{
 		"check:",
 		"minReplicas must not exceed maxReplicas",
-		"self.minReplicas <= self.maxReplicas",
+		"(minReplicas <= maxReplicas)", // from `self.minReplicas <= self.maxReplicas` with `self.` stripped
 		"cronSpec must be a valid cron expression",
-		"_regex_match(str(self.cronSpec)",
-		"len(self) >= 1", // from `size(self) >= 1` -> `len(self) >= 1`
-		"spec must have at least one property",
+		"_regex_match(str(cronSpec)", // from `self.cronSpec.matches(...)` with `self.` stripped
 	} {
 		if !strings.Contains(content, want) {
 			t.Errorf("expected %q in spec.k:\n%s", want, content)
 		}
 	}
+	// The header must import `regex` and alias `_regex_match = regex.match`
+	// because the CEL rule `self.cronSpec.matches(...)` translates to
+	// `_regex_match(...)` inside the `check:` block. Without these the
+	// generated file references an undefined identifier.
+	for _, want := range []string{
+		"import regex",
+		"_regex_match = regex.match",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("expected %q in spec.k header:\n%s", want, content)
+		}
+	}
+	// `size(self)` has no faithful KCL equivalent inside a `check:`
+	// block (KCL has no handle on the schema instance), so the rule
+	// and its message are dropped by the translator. Asserting the
+	// negative guarantees we don't regress back to emitting
+	// `len(self) >= 1` (which would not compile).
+	for _, notWant := range []string{
+		"len(self)",
+		"spec must have at least one property",
+	} {
+		if strings.Contains(content, notWant) {
+			t.Errorf("did not expect %q in spec.k (rule should be dropped):\n%s", notWant, content)
+		}
+	}
 	if strings.Contains(content, "__UNSUPPORTED_CEL_CALL_") {
 		t.Errorf("found unsupported CEL call marker in spec.k:\n%s", content)
 	}
+	// Finally, compile the generated file with `kcl` to make sure the
+	// translator's output is actually valid KCL — not just text that
+	// happens to contain the substrings above.
+	if kcl := lookupKCLBinary(t); kcl != "" {
+		cmd := exec.Command(kcl, specFile)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("kcl compile failed for generated %s:\n%s\n%v", specFile, string(out), err)
+		}
+	}
+}
+
+// lookupKCLBinary resolves a `kcl` executable for the e2e compile check.
+// The path comes from (in priority order): $KCL_BIN, the `kcl` discovered
+// via $PATH, or the well-known homebrew install location. Returns "" if no
+// binary can be found, in which case the e2e test skips the compile step
+// — substring checks above still run.
+func lookupKCLBinary(t *testing.T) string {
+	t.Helper()
+	if p := os.Getenv("KCL_BIN"); p != "" {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	if p, err := exec.LookPath("kcl"); err == nil {
+		return p
+	}
+	for _, p := range []string{
+		"/opt/homebrew/bin/kcl",
+		"/usr/local/bin/kcl",
+	} {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return ""
 }
 
 func TestGenerate_CRD2KCL_PackageRoot(t *testing.T) {


### PR DESCRIPTION
## Summary

The CEL→KCL translator introduced in #161 produced `check:` blocks that didn't actually compile under KCL. kcl-lang/modules PR #401 hit this and worked around it by dropping the entire `check:` block on regeneration. This PR makes the translation faithful enough to keep the rules.

## What was wrong

| CEL input | Old output | Why it failed in KCL |
| --- | --- | --- |
| `self.minReplicas <= self.maxReplicas` | `(self.minReplicas <= self.maxReplicas)` | `self` is not in scope inside `check:` |
| `has(self.foo)` | `(has self.foo)` | no `has` keyword |
| `!has(self.foo)` | `(not ((has self.foo)))` | same |
| `cond ? a : b` | `("x") if (self.a) else ("y")` | `else` is parsed as a bare name inside `check:` |
| `size(self)` | `len(self)` | no handle on the schema instance |
| `self.cronSpec.matches(...)` | `_regex_match(str(self.cronSpec), ...)` | compiled, but the header didn't import `regex` unless a JSON Schema `pattern` was also set, so `_regex_match` was undefined |

## What changes

`pkg/swagger/generator/cel.go`
- New `emitSelect` helper. When the operand is bare `self`, strips the prefix on field access and translates `has(self.X)` → `(X != None)`. Non-`self` `has(m.X)` is surfaced as unsupported.
- Ternary in `emitCall` now returns the `__UNSUPPORTED_CEL_CALL_ternary__` placeholder so the caller drops the rule (KCL `check:` rejects `if/else`).
- `size(self)` short-circuits to unsupported; `size(self.x)` still becomes `len(x)`.
- New `isSelfIdent` helper.

`pkg/swagger/generator/model.go`
- `getBuiltInImports` now also walks `CheckExprs` for any translated expression containing `_regex_match`, so the `regex` import and the `_regex_match = regex.match` alias appear whenever a CEL rule uses `.matches(...)`, not only when `schema.Pattern != ""`.

`pkg/swagger/generator/cel_test.go`
- All 27 existing expectations synced to the new translator output.
- New cases for `!has(self.foo)`, `size(self)`, and ternary-as-unsupported.
- The post-check that flagged unsupported placeholders now whitelists any case whose `want` value is itself a `__UNSUPPORTED_CEL_CALL_*` marker.

`pkg/swagger/generator/support_test.go`
- `TestGenerate_OAI2KCL_K8sValidations` now also invokes `kcl` on the generated file via a new `lookupKCLBinary` helper (`$KCL_BIN` → `$PATH` → homebrew) and fails the test if the file doesn't compile.
- Existing assertions tightened: `self.` is now expected stripped; `len(self)` and the rule's message are now expected absent (the rule is correctly dropped).

## Verification

- `go test ./...` — all pass.
- The extended e2e test compiles the generated `spec.k` with the system `kcl` 0.12.3.
- Manual run with valid values → produces the expected schema instance.
- Manual run with an invalid `cronSpec` → `Instance check failed` pointing at the `_regex_match` line.
- Manual run with a missing required attribute → `'<=' not supported between instances of 'UndefinedType' and 'int'` pointing at the `(minReplicas <= maxReplicas)` line.

Both error cases point at the exact `check:` line that should fail, confirming the translated rules actually evaluate at runtime — not just parse.

## References

- #161 (original CEL→KCL feature)
- kcl-lang/modules#401 (where the bug was observed downstream)